### PR TITLE
fix: fixed ImageViewer display for Firefox, Safari

### DIFF
--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -23,7 +23,7 @@
 }
 
 .header > * {
-  flex: 1 0 auto;
+  flex: 0 0 auto;
   margin: 0;
 }
 
@@ -87,10 +87,6 @@
     margin-right: 0.75rem;
     height: 1.25em;
     width: 1.25em;
-  }
-
-  .header > * {
-    flex: unset;
   }
 
   .header > :not(:first-child) {

--- a/src/components/Image/ImageViewer/ImageViewer.module.css
+++ b/src/components/Image/ImageViewer/ImageViewer.module.css
@@ -1,9 +1,10 @@
 .canvas {
   min-height: 100%;
   max-width: 100%;
+  object-fit: cover;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 1200px) {
   .canvas {
     position: absolute;
     top: 50%;


### PR DESCRIPTION
This PR fixes squashed images in the `<ImageViewer />` component on Firefox & Safari